### PR TITLE
FIX：修复创建多实例造成的fclose错误

### DIFF
--- a/src/IP2City.php
+++ b/src/IP2City.php
@@ -11,7 +11,6 @@ namespace MyLukin\IP2City;
 class IP2City
 {
 
-    private static $ip = NULL;
     private static $fp = NULL;
     private static $offset = NULL;
     private static $index = NULL;
@@ -93,7 +92,6 @@ class IP2City
     private static function init()
     {
         if (self::$fp === NULL) {
-            self::$ip = new self(self::$datFile);
 
             self::$fp = fopen(self::$datFile, 'rb');
             if (self::$fp === FALSE) {


### PR DESCRIPTION
#2 删除了没有用到的静态$ip变量，不会出现多次关闭文件导致的报错了